### PR TITLE
Fix for checkpoint issue

### DIFF
--- a/examples/oft-evm-move-adapters/sources/shared_oft/oft_impl_config.move
+++ b/examples/oft-evm-move-adapters/sources/shared_oft/oft_impl_config.move
@@ -213,7 +213,7 @@ module oft::oft_impl_config {
 
     /// Checkpoint the in-flight amount for a given EID for the provided timestamp.
     /// This should whenever there is a change in rate limit or before consuming rate limit capacity
-    public fun checkpoint_rate_limit_in_flight(eid: u32, timestamp: u64) acquires Config {
+    public(friend) fun checkpoint_rate_limit_in_flight(eid: u32, timestamp: u64) acquires Config {
         let inflight = in_flight_at_time(eid, timestamp);
         let rate_limit = table::borrow_mut(&mut store_mut().rate_limit_by_eid, eid);
         rate_limit.in_flight_on_last_update = inflight;

--- a/examples/oft-evm-move-adapters/sources/shared_oft/oft_impl_config.move
+++ b/examples/oft-evm-move-adapters/sources/shared_oft/oft_impl_config.move
@@ -213,7 +213,7 @@ module oft::oft_impl_config {
 
     /// Checkpoint the in-flight amount for a given EID for the provided timestamp.
     /// This should whenever there is a change in rate limit or before consuming rate limit capacity
-    public(friend) fun checkpoint_rate_limit_in_flight(eid: u32, timestamp: u64) acquires Config {
+    public fun checkpoint_rate_limit_in_flight(eid: u32, timestamp: u64) acquires Config {
         let inflight = in_flight_at_time(eid, timestamp);
         let rate_limit = table::borrow_mut(&mut store_mut().rate_limit_by_eid, eid);
         rate_limit.in_flight_on_last_update = inflight;
@@ -307,6 +307,9 @@ module oft::oft_impl_config {
     /// This will release the capacity back to the rate limit up to the limit itself
     public(friend) fun release_rate_limit_capacity(eid: u32, amount: u64) acquires Config {
         if (!has_rate_limit(eid)) return;
+
+        // Checkpoint to account for decay before modifying in_flight_on_last_update
+        checkpoint_rate_limit_in_flight(eid, timestamp::now_seconds());
 
         let rate_limit = table::borrow_mut(&mut store_mut().rate_limit_by_eid, eid);
         if (amount >= rate_limit.in_flight_on_last_update) {


### PR DESCRIPTION
## Security Fix: Add Checkpoint in `release_rate_limit_capacity`

- Fix for issue 1 in https://www.notion.so/movementlabs/OFT-issues-2ae18675b2d780af9013ee9082afccdd
- Add checkpoint before modifying `in_flight_on_last_update` in `release_rate_limit_capacity` to account for decay, preventing loss of decay information and potential rate limit bypass exploits
- Fixes issue where multiple releases in quick succession could use outdated `in_flight_on_last_update` values, matching the pattern used in `try_consume_rate_limit_capacity_at_time`