### PR TITLE
Fix lazy evaluation pattern in rate limit decay

### DIFF
--- a/examples/oft-evm-move-adapters/sources/shared_oft/oft_impl_config.move
+++ b/examples/oft-evm-move-adapters/sources/shared_oft/oft_impl_config.move
@@ -1,6 +1,5 @@
 module oft::oft_impl_config {
     use std::event::emit;
-    use std::math64::min;
     use std::string::utf8;
     use std::table::{Self, Table};
     use std::timestamp;

--- a/examples/oft-evm-move-adapters/sources/shared_oft/oft_impl_config.move
+++ b/examples/oft-evm-move-adapters/sources/shared_oft/oft_impl_config.move
@@ -216,9 +216,7 @@ module oft::oft_impl_config {
     public(friend) fun checkpoint_rate_limit_in_flight(eid: u32, timestamp: u64) acquires Config {
         let inflight = in_flight_at_time(eid, timestamp);
         let rate_limit = table::borrow_mut(&mut store_mut().rate_limit_by_eid, eid);
-        // Cap in_flight_on_last_update to the current limit to prevent it from exceeding the limit
-        // when the limit is lowered
-        rate_limit.in_flight_on_last_update = min(inflight, rate_limit.limit);
+        rate_limit.in_flight_on_last_update = inflight;
         rate_limit.last_update = timestamp;
     }
 

--- a/examples/oft-evm-move-adapters/tests/implementations/move_oft_adapter_tests.move
+++ b/examples/oft-evm-move-adapters/tests/implementations/move_oft_adapter_tests.move
@@ -33,6 +33,8 @@ module oft::move_oft_adapter_tests {
         remove_pauser,
         set_fee_bps,
         set_fee_deposit_address,
+        EPAUSED,
+        EUNAUTHORIZED,
     };
     use oft::oft_impl_config;
     use oft::oft_store;
@@ -85,7 +87,7 @@ module oft::move_oft_adapter_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = 5)] // EUNAUTHORIZED
+    #[expected_failure(abort_code = EUNAUTHORIZED, location = move_oft_adapter)]
     fun test_only_pauser_or_admin_can_toggle() {
         setup();
 
@@ -97,7 +99,7 @@ module oft::move_oft_adapter_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = 4)] // EPAUSED
+    #[expected_failure(abort_code = EPAUSED, location = move_oft_adapter)]
     fun test_paused_blocks_debit() {
         let mint_ref = setup();
         let admin = &create_signer_for_test(@oft_admin);
@@ -149,7 +151,7 @@ module oft::move_oft_adapter_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = 5)] // EUNAUTHORIZED
+    #[expected_failure(abort_code = EUNAUTHORIZED, location = move_oft_adapter)]
     fun test_non_pauser_still_unauthorized() {
         setup();
         let admin = &create_signer_for_test(@oft_admin);
@@ -160,7 +162,7 @@ module oft::move_oft_adapter_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = 4)] // EPAUSED
+    #[expected_failure(abort_code = EPAUSED, location = move_oft_adapter)]
     fun test_credit_blocked_when_paused() {
         let mint_ref = setup();
         let amount_ld = 500u64;
@@ -181,7 +183,7 @@ module oft::move_oft_adapter_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = 5)] // EUNAUTHORIZED
+    #[expected_failure(abort_code = EUNAUTHORIZED, location = move_oft_adapter)]
     fun test_removed_pauser_loses_ability() {
         setup();
 


### PR DESCRIPTION
## Fix lazy evaluation pattern in rate limit decay (problem 2 in https://www.notion.so/movementlabs/OFT-issues-2ae18675b2d780af9013ee9082afccdd)

- Remove `min()` cap on elapsed time calculation in `in_flight_at_time` to allow decay to continue beyond one window, preventing `in_flight_on_last_update` from getting stuck above the limit when the limit is lowered
- Clean up Move warnings