### PR TITLE
modify rate limit behavior on incoming funds

### DIFF
--- a/examples/oft-evm-move-adapters/sources/oft_implementation/move_oft_adapter.move
+++ b/examples/oft-evm-move-adapters/sources/oft_implementation/move_oft_adapter.move
@@ -53,7 +53,7 @@ module oft::move_oft_adapter {
     public(friend) fun credit(
         to: address,
         amount_ld: u64,
-        src_eid: u32,
+        _src_eid: u32,
         lz_receive_value: Option<FungibleAsset>,
     ): u64 acquires OftImpl, PauserStore {
         // Global inflow pause gate

--- a/examples/oft-evm-move-adapters/sources/oft_implementation/move_oft_adapter.move
+++ b/examples/oft-evm-move-adapters/sources/oft_implementation/move_oft_adapter.move
@@ -26,7 +26,7 @@ module oft::move_oft_adapter {
         assert_not_blocklisted,
         debit_view_with_possible_fee,
         fee_details_with_possible_fee,
-        redirect_to_admin_if_blocklisted, release_rate_limit_capacity, try_consume_rate_limit_capacity
+        redirect_to_admin_if_blocklisted, try_consume_rate_limit_capacity
     };
     use oft_common::oft_fee_detail::OftFeeDetail;
     use oft_common::oft_limit::{Self, OftLimit};
@@ -61,8 +61,8 @@ module oft::move_oft_adapter {
         // Default implementation does not make special use of LZ Receive Value sent; just deposit to the OFT address
         option::for_each(lz_receive_value, |fa| primary_fungible_store::deposit(@oft_admin, fa));
 
-        // Release rate limit capacity for the pathway (net inflow)
-        release_rate_limit_capacity(src_eid, amount_ld);
+        // Consume rate limit capacity for the pathway (net inflow), based on the amount received on this side
+        try_consume_rate_limit_capacity(30325, amount_ld);
 
         // unlock the amount from escrow
         let escrow_signer = &object::generate_signer_for_extending(&store().escrow_extend_ref);

--- a/examples/oft-evm-move-adapters/tests/oft_using_move_oft_adapter_tests.move
+++ b/examples/oft-evm-move-adapters/tests/oft_using_move_oft_adapter_tests.move
@@ -318,7 +318,6 @@ module oft::oft_using_move_oft_adapter_tests {
         );
 
         // Modified behavior on move_oft_adapter.move,  send_withdraw should NOT be offset by lz_receive.
-                // Succeeds: consumes 15_000_000_000 of 19_000_000_000 in flight
         send_withdraw(alice, DST_EID, bob, amount, amount, vector[], vector[], vector[], 0, 0);
     }
 

--- a/examples/oft-evm-move-adapters/tests/oft_using_move_oft_adapter_tests.move
+++ b/examples/oft-evm-move-adapters/tests/oft_using_move_oft_adapter_tests.move
@@ -257,6 +257,7 @@ module oft::oft_using_move_oft_adapter_tests {
     }
 
     #[test]
+    #[expected_failure(abort_code = oft::oft_impl_config::EEXCEEDED_RATE_LIMIT)]
     fun test_send_rate_limit_netted_by_receive() {
         let mint_ref = setup(SRC_EID, DST_EID);
         set_rate_limit(&create_signer_for_test(@oft_admin), DST_EID, 19_000_000_000, 10);
@@ -316,7 +317,8 @@ module oft::oft_using_move_oft_adapter_tests {
             vector[],
         );
 
-        // Succeeds: consumes 15_000_000_000 of 19_000_000_000 in flight
+        // Modified behavior on move_oft_adapter.move,  send_withdraw should NOT be offset by lz_receive.
+                // Succeeds: consumes 15_000_000_000 of 19_000_000_000 in flight
         send_withdraw(alice, DST_EID, bob, amount, amount, vector[], vector[], vector[], 0, 0);
     }
 


### PR DESCRIPTION
Goals:
* incoming rate limit of 100m
* remove the possibility of the rate limiting being offset

Changes behavior on incoming funds by removing release_rate_limit_capacity and adding try_consume_rate_limit_capacity on the Movement endpoint.